### PR TITLE
修复Windows系统下载zip文件损坏的错误

### DIFF
--- a/R/install_zip.R
+++ b/R/install_zip.R
@@ -12,7 +12,9 @@ install_zip_gh <- function(repo, ref = "master", args = "--no-build-vignettes") 
     ## repo <- 'GuangchuangYu/nCov2019'
     url <- paste0('https://codeload.github.com/', repo, '/zip/', ref)
     f <- tempfile(fileext=".zip")
-    downloader::download(url, destfile=f)
+    method <- "auto"
+    if (Sys.info()[["sysname"]] == "Windows") method <- "curl"
+    download.file(url, destfile=f, method = method)
     install_zip(f, args=args)
 }
 

--- a/R/install_zip.R
+++ b/R/install_zip.R
@@ -13,7 +13,7 @@ install_zip_gh <- function(repo, ref = "master", args = "--no-build-vignettes") 
     url <- paste0('https://codeload.github.com/', repo, '/zip/', ref)
     f <- tempfile(fileext=".zip")
     method <- "auto"
-    if (Sys.info()[["sysname"]] == "Windows") method <- "curl"
+    if (.Platform$OS.type == "windows") method <- "curl"
     download.file(url, destfile=f, method = method)
     install_zip(f, args=args)
 }


### PR DESCRIPTION
我在 Windows 10 系统，R 4.0 的环境下使用时，下载的 zip 文件损坏打不开，经排查是 `download.file` 的 `method` 参数设置问题。在所有支持的 `method` 中，`wininet`，`libcurl` 都是同样损坏，只有 `curl` 方法下载的 zip 文件是可用的。

所以，在 Windows 系统中，有此改动。这解决了我的问题。但是不知道有没有普适性。