### PR TITLE
fix install problem in windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,4 +11,4 @@ Description: What the package does (one paragraph).
 License: What license it uses
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/R/install_zip.R
+++ b/R/install_zip.R
@@ -37,5 +37,5 @@ install_zip <- function(file, args = "--no-build-vignettes") {
     ## dir <- paste0(dir, '/', basename(repo), '-master')
     ## remotes::install_local(path=dir, ..., force=TRUE)
     pkg <- pkgbuild::build(dir, args=args)
-    install.packages(pkg)
+    install.packages(pkg, repos=NULL)
 }


### PR DESCRIPTION
windows 下安装本地`build`好的包，如果没有把`install.package`里的`repos`设为`NULL`，会到默认指定的镜像源里找而报错。
所以我把`repos`指定为`NULL`.