### PR TITLE
Convert path into absolute form before opening

### DIFF
--- a/R/file.R
+++ b/R/file.R
@@ -74,6 +74,7 @@ read.cb <- function(reader = read.table, ...) {
 ##'
 ##' @title o
 ##' @param file to be open; open workding directory by default
+##' @param file to be open; open working directory by default
 ##' @return No return value, called for opening specific directory or file
 ##' @examples
 ##' \dontrun{
@@ -83,6 +84,7 @@ read.cb <- function(reader = read.table, ...) {
 ##' @export
 ##' @author Guangchuang Yu
 o <- function(file=".") {
+    file <- normalizePath(file)
     os <- Sys.info()[1]
     if (is.rserver()) {
         if (dir.exists(file)) {

--- a/R/file.R
+++ b/R/file.R
@@ -73,7 +73,6 @@ read.cb <- function(reader = read.table, ...) {
 ##'
 ##'
 ##' @title o
-##' @param file to be open; open workding directory by default
 ##' @param file to be open; open working directory by default
 ##' @return No return value, called for opening specific directory or file
 ##' @examples


### PR DESCRIPTION
1. Bug arise if I open directory under working directory, such as "./R", which can be fixed by using a absolute path.
2. Typo of "working".

-----

Y叔好，之前我一直都有一边处理数据，一边把中间数据用excel打开来看的习惯（比如特别长的文本在R里面就不太方便查看），或者是在保存图片前先打开看看（调图片的比例），因此写了很多preview_*的函数，比如：

preview_gg <- function(plot, width = 6, height = 4, ext = "png", ...) {
  fname <- tempfile(fileext = paste0(".", ext))
  ggplot2::ggsave(
    filename = fname, plot = plot, height = height, width = width, 
    ...
  )
  utils::browseURL(fname)
  invisible(NULL)
}


所以当我顺着您最近的推文《加载包顺道把包给安装了》翻到了过去的《在Excel里瞄一瞄你的数据吧》时，感到特别的亲切。而在看到o()这个函数的时候，感觉非常的敬佩，开发者把很多情况都考虑到了，实现了文件打开的大一统。我一开始只在Windows里面预览文件，所以用的是system(paste("open", fname))，后面需要在Rserver上面预览，就改成了utils::browseURL(fname)，没想到还有这么多情况没有考虑到，学习了。

这次也是在玩o()的时候，发现没办法打开工作目录以外的其他路径，因此尝试写了人生中的第一个pull request。但是我只在Windows上面测试过，**不知道其他系统的情况**。
