### PR TITLE
Add parameter for IP and port of RServer

### DIFF
--- a/R/file.R
+++ b/R/file.R
@@ -82,15 +82,15 @@ read.cb <- function(reader = read.table, ...) {
 ##' }
 ##' @export
 ##' @author Guangchuang Yu
-o <- function(file=".") {
+o <- function(file = ".", rserver_ip = NULL, rserver_port = NULL) {
     os <- Sys.info()[1]
     if (is.rserver()) {
         if (dir.exists(file)) {
             stop("open directory in RStudio Server is not supported.")
         }
-        rserver_ip <- getOption("rserver_ip")
+         rserver_ip <- getOption("rserver_ip") %||% rserver_ip
         if (!is.null(rserver_ip)) {
-            rserver_port <- getOption("rserver_port") %||% '8787' 
+            rserver_port <-  getOption("rserver_port") %||% rserver_port %||% '8787'
             if (!startsWith(rserver_ip, "http")) {
                 rserver_ip = paste0("http://", rserver_ip)
             }


### PR DESCRIPTION
Bug arise when the NULL return from getOption("rserver_ip").

-----

Y叔好，我又来了。

我在使用o()的时候，发现这个函数不能在Rserver中打开图片，究其原因，是因为getOption("rserver_ip")是NULL，所以调用的是file.edit()，我不太清楚为什么我在Rserver里面没有"rserver_ip"这个设置，但是如果可以手动添加rserver_ip的话，这个问题就可以解决了。

-----

wuwr25@mail.sysu.edu.cn